### PR TITLE
Fixed typo in gcloud command

### DIFF
--- a/courses/machine_learning/cloudmle/cloudmle.ipynb
+++ b/courses/machine_learning/cloudmle/cloudmle.ipynb
@@ -286,7 +286,7 @@
     "JOBNAME=lab3a_$(date -u +%y%m%d_%H%M%S)\n",
     "echo $OUTDIR $REGION $JOBNAME\n",
     "gsutil -m rm -rf $OUTDIR\n",
-    "gcloud ai-platfrom jobs submit training $JOBNAME \\\n",
+    "gcloud ai-platform jobs submit training $JOBNAME \\\n",
     "   --region=$REGION \\\n",
     "   --module-name=trainer.task \\\n",
     "   --package-path=${PWD}/taxifare/trainer \\\n",


### PR DESCRIPTION
In section "Submit training job using gcloud", gcloud was called with "ai-platfrom" instead of "ai-platform".
This caused the example notebook to fail with error.